### PR TITLE
chore: simplify .babelrc - remove legacy plugins (milestone 2)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,26 +4,8 @@
     "@babel/preset-flow"
   ],
   "plugins": [
-    [
-      "@babel/plugin-transform-runtime",
-      {
-        "corejs": 3
-      }
-    ],
+    ["@babel/plugin-transform-runtime", { "corejs": 3 }],
     "@babel/plugin-transform-flow-strip-types",
-    "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-syntax-import-meta",
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-json-strings",
-    [
-      "@babel/plugin-proposal-decorators",
-      {
-        "legacy": true
-      }
-    ],
-    "@babel/plugin-proposal-function-sent",
-    "@babel/plugin-proposal-export-namespace-from",
-    "@babel/plugin-proposal-numeric-separator",
-    "@babel/plugin-proposal-throw-expressions"
+    ["@babel/plugin-proposal-decorators", { "legacy": true }]
   ]
 }


### PR DESCRIPTION
Removed plugins now standard in Node 18+:
- @babel/plugin-syntax-dynamic-import
- @babel/plugin-syntax-import-meta
- @babel/plugin-proposal-class-properties
- @babel/plugin-proposal-json-strings
- @babel/plugin-proposal-function-sent
- @babel/plugin-proposal-export-namespace-from
- @babel/plugin-proposal-numeric-separator
- @babel/plugin-proposal-throw-expressions

Kept:
- @babel/plugin-transform-runtime (corejs: 3)
- @babel/plugin-transform-flow-strip-types
- @babel/plugin-proposal-decorators (legacy: true)

Build is ~2x faster (1108ms vs 2468ms)