### PR TITLE
feat: add fetch wrapper abstraction (slices 4a-4d)

### DIFF
--- a/lib/util/fetch.js
+++ b/lib/util/fetch.js
@@ -8,4 +8,4 @@ _Object$defineProperty(exports, "__esModule", {
 exports["default"] = void 0;
 var _nodeFetch = _interopRequireDefault(require("node-fetch"));
 /* global fetch */
-var _default = exports["default"] = fetch;
+var _default = exports["default"] = _nodeFetch["default"];

--- a/lib/util/fetch.js
+++ b/lib/util/fetch.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+var _interopRequireDefault = require("@babel/runtime-corejs3/helpers/interopRequireDefault");
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var _nodeFetch = _interopRequireDefault(require("node-fetch"));
+/* global fetch */
+var _default = exports["default"] = fetch;

--- a/lib/util/fetch.js
+++ b/lib/util/fetch.js
@@ -7,5 +7,4 @@ _Object$defineProperty(exports, "__esModule", {
 });
 exports["default"] = void 0;
 var _nodeFetch = _interopRequireDefault(require("node-fetch"));
-/* global fetch */
 var _default = exports["default"] = _nodeFetch["default"];

--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -14,7 +14,7 @@ var _isFinite = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-s
 var _promise = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/promise"));
 var _setTimeout2 = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/set-timeout"));
 var _includes = _interopRequireDefault(require("@babel/runtime-corejs3/core-js-stable/instance/includes"));
-var _nodeFetch = _interopRequireDefault(require("node-fetch"));
+var _fetch = _interopRequireDefault(require("./fetch"));
 var _httpsProxyAgent = _interopRequireDefault(require("https-proxy-agent"));
 /* global AbortController */
 var DEFAULT_TIMEOUT_MS = 10000;
@@ -77,7 +77,7 @@ var _default = exports["default"] = /*#__PURE__*/function () {
                   options.signal = controller.signal;
                   _context.prev = 1;
                   _context.next = 2;
-                  return (0, _nodeFetch["default"])(url, options);
+                  return (0, _fetch["default"])(url, options);
                 case 2:
                   _t = _context.sent;
                   return _context.abrupt("return", {
@@ -102,7 +102,7 @@ var _default = exports["default"] = /*#__PURE__*/function () {
                 case 6:
                   _context.prev = 6;
                   _context.next = 7;
-                  return (0, _nodeFetch["default"])(url, options);
+                  return (0, _fetch["default"])(url, options);
                 case 7:
                   _t3 = _context.sent;
                   return _context.abrupt("return", {
@@ -143,7 +143,7 @@ var _default = exports["default"] = /*#__PURE__*/function () {
           _context2.next = 1;
           break;
         case 4:
-          return _context2.abrupt("return", (0, _nodeFetch["default"])(url, options));
+          return _context2.abrupt("return", (0, _fetch["default"])(url, options));
         case 5:
         case "end":
           return _context2.stop();

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,0 +1,5 @@
+/* @flow */
+/* global fetch */
+import nodeFetch from 'node-fetch'
+
+export default fetch

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -1,5 +1,4 @@
 /* @flow */
-/* global fetch */
 import nodeFetch from 'node-fetch'
 
 export default nodeFetch

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -2,4 +2,4 @@
 /* global fetch */
 import nodeFetch from 'node-fetch'
 
-export default fetch
+export default nodeFetch

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -1,6 +1,6 @@
 /* @flow */
 /* global AbortController */
-import fetch from 'node-fetch'
+import fetch from './fetch'
 import HttpsProxyAgent from 'https-proxy-agent'
 
 const DEFAULT_TIMEOUT_MS = 10000


### PR DESCRIPTION
## Summary
- Create `src/util/fetch.js` as fetch abstraction layer
- Integrate fetch wrapper into `src/util/request.js`
- All 17 providers now use fetch through the wrapper

## Slices
- 4a: Create fetch wrapper ✅
- 4b: Integrate into request.js ✅
- 4c: Migrate all providers (automatic) ✅
- 4d: Switch to native fetch - Deferred (needs test mocking updates)

## Notes
Native fetch switch is deferred - requires updating 17 test files to mock fetch instead of https.request. The abstraction is in place for easy switch later.